### PR TITLE
Fixed bugs in the Acto Validator which incorrectly was setting number…

### DIFF
--- a/models/storyPoint.js
+++ b/models/storyPoint.js
@@ -10,6 +10,14 @@ export const storyPointSchema = new Schema([{
     storyPoint: {
         type: Number,
         required: true,
-        enum: [0,1, 2, 3, 5, 8, 13]
+        enum: [0,1, 2, 3, 5, 8, 13],
+        validate: {
+            validator: function(val) {
+              if(val.length !== 0) {
+                return false;
+              }
+            },
+            message: "A story point is required, either 0, 1, 2, 3, 5, 8, or 13"
+        }
     }
 }])

--- a/services/validators/ActoValidator.js
+++ b/services/validators/ActoValidator.js
@@ -9,9 +9,9 @@ export class ActoValidator {
     constructor() {
         
         // @prop {number} value - is the value being validated
-        // it is initialized as a negative value so it must be mutated to 
+        // it is initialized as a null  so it must be mutated to 
         // a positive number
-        this.value = -1;
+        this.value = null;
 
         // @prop {boolean} chainable - defines if or if not a method is chaninable
         this.chainable = true;
@@ -76,13 +76,16 @@ export class ActoValidator {
         return this;
     }
    
-    notEmpty(val) {
+    notEmpty(val = null) {
+        if( '' !== val && null == this.value) {
+            this.value = val;
+        }
         let error = {statusCode: 204, message:`notEmpty(val): val is empty, it needs a value to test`};
         if (typeof val === 'string') {
-            val.trim()
+            this.value.trim()
         }
         // verify val is not either null or empty. Trim in-case of leading whitespace
-        if(val === null || val.length === 0) {
+        if(this.value === null || this.value.length === 0) {
             throw error;
         }
         
@@ -90,7 +93,7 @@ export class ActoValidator {
             console.log(`inside chainable`)
             return this
         } else {
-            this.field = val;
+            this.field = this.value;
             return this.field.length !== 0
         }
     }

--- a/tests/unit/Validator.test.js
+++ b/tests/unit/Validator.test.js
@@ -77,6 +77,24 @@ test('notEmpty()', async t => {
     t.true(Validator.notEmpty({}))
 })
 
+test('Validation should chain', async t => {
+    const Validator = new ActoValidator();
+    const validateThis = Validator.validate(2).notEmpty().num();
+    t.is(validateThis.value, 2);
+    t.true(validateThis.chainable);
+    t.true(validateThis.pass)
+})
+
+test('Validation should throw validation error at any point in the chained functions', async t => {
+    const Validator = new ActoValidator();
+    try {
+        Validator.validate('2').notEmpty().num();
+    } catch(e) {
+        t.is(e.statusCode, 406);
+        t.is(e.message, 'Expect checked value to be number, string given')
+    }
+})
+
 // test(".notEmpty(val) should error when val is empty", async t => {
 //     const Validator = new ActoValidator();
 //     try {

--- a/tests/unit/issuesModel.test.js
+++ b/tests/unit/issuesModel.test.js
@@ -10,6 +10,7 @@ test("Validate should throw all validation errors with none of the required issu
         await except();
     } catch(e) {
         const errors = JSON.stringify(e);
+        console.log(errors)
         /**
          * {"errors":{"description":{"name":"ValidatorError",
          * "message":"Path `description` is required.",


### PR DESCRIPTION
…s to string. Added custom validation to storyPoint schema which DID NOT fix the validation from being thrown. I create a stack overflow ticket [](https://stackoverflow.com/questions/77602528/mongoose-validation-falling-for-embedded-document)