### PR TITLE
Copied  all of the SprintCommittment code to a new Sprints class; the…

### DIFF
--- a/controllers/story_point_controller.js
+++ b/controllers/story_point_controller.js
@@ -15,13 +15,13 @@ export const story_point_get = async (req, res) => {
 }
 
 export const story_points_create_post = async (req, res) => {
-    // console.log('req', req)
-    // console.log('res', res)
-    // connectDB();
-    // let storyPoints = new StoryPoints({
-    //     sprint: req.body.sprint,
-    //     issues: req.body.issues 
-    // })
+    console.log('req', req)
+    console.log('res', res)
+    connectDB();
+    let storyPoints = new StoryPoints({
+        sprint: req.body.sprint,
+        issues: req.body.issues 
+    })
 
     // try {
     //     const savedStoryPoint = await storyPoints.save();

--- a/plugins/Jira/services/Sprints.js
+++ b/plugins/Jira/services/Sprints.js
@@ -1,0 +1,60 @@
+import { JiraRest } from "./jiraRest.js";
+import { config } from "./config.js";
+
+export class Sprints {
+    constructor(JiraRestInstance) {
+        // Ensure we have a Jira Rest instance passed
+        if (JiraRestInstance instanceof JiraRest) {
+            this.jr = JiraRestInstance; // Assign the passed instance, not the class
+        } else {
+            throw new Error('SprintCommitment requires a JiraRest instance as the first parameter');
+        }
+    }
+     /**
+     * Get Sprints for the Board
+     * Retrieve the sprints for a given board ID:
+     * @param {number} boardId 
+     * @returns 
+     */
+     async getSprints(boardId, queryParams = { state: 'active' }) {
+        try {
+            const jiraBaseUri = process.env.JIRA_API_BASE_URI;
+            const uriPath = `/agile/1.0/board/${boardId}/sprint`;
+
+            // Handle query parameters
+            const queryString = new URLSearchParams(queryParams).toString();
+            const fullUri = `${jiraBaseUri}${uriPath}${queryString ? '?' + queryString : ''}`;
+
+            const response = await this.jr.call(fullUri);
+
+            return response;
+        } catch (error) {
+            console.error('Error fetching sprints:', error);
+            return [];
+        }
+    }
+   
+    /**
+     * Get Issues in the Identified Sprint
+     * Retrieve issues for a given sprint ID that will be used to get the story points:
+     * @param {number} sprintId 
+     * @returns 
+     */
+    async getIssuesInSprint(sprintId, queryParams = {}) {
+        try {
+            // Replace placeholders in the URI pattern with actual values
+            const uriPath = config.JIRA_API_SPRINT_ISSUES_PATH.replace('{sprintId}', sprintId);
+            // Construct the full URI with the base and path
+            const uri = `${config.JIRA_API_BASE_URI}${uriPath}`;
+              // Handle query parameters
+            const queryString = new URLSearchParams(queryParams).toString();
+            const fullUri = `${uri}${queryString ? '?' + queryString : ''}`;
+            console.log(fullUri)
+            const response = await this.jr.call(fullUri);
+            return response.issues;
+        } catch (error) {
+            console.error('Error fetching issues:', error);
+            return [];
+        }
+    }
+}

--- a/plugins/toolPlugin.js
+++ b/plugins/toolPlugin.js
@@ -1,0 +1,13 @@
+class ToolPlugin {
+    getSprints(boardId) {
+        throw new Error("Method 'getSprints()' must be implemented.");
+    }
+    
+    getIssuesInSprint(sprintId) {
+        throw new Error("Method 'getIssuesInSprint()' must be implemented.");
+    }
+    
+    getStoryPoints(issue) {
+        throw new Error("Method 'getStoryPoints()' must be implemented.");
+    }
+}

--- a/tests/unit/services/JiraPlugin/Sprints.test.js
+++ b/tests/unit/services/JiraPlugin/Sprints.test.js
@@ -1,0 +1,53 @@
+import test from 'ava';
+import { JiraRest } from '../../../../plugins/Jira/services/jiraRest.js';
+import { ActoValidator } from '../../../../services/validators/ActoValidator.js';
+import { Sprints } from '../../../../plugins/Jira/services/Sprints.js';
+
+let jr;
+let Sp;
+
+test.before(() => {
+    jr = new JiraRest(new ActoValidator());
+    Sp = new Sprints(jr);
+});
+
+test.after.always(() => {
+    jr = null;
+    Sp = null;
+});
+
+test('Sprints should set the jr property if an instance of JiraRest is passed', t => {
+    t.true(Sp.jr instanceof JiraRest);
+});
+
+test('Sprints should not throw an error if a JiraRest instance is passed', t => {
+    t.notThrows(() => {
+        new Sprints(jr);
+    });
+});
+
+test('Sprints should fetch an active sprint on board 167', async t => {
+    const res = await Sp.getSprints(167);
+    t.true(res.values.length > 0);
+
+    const activeSprint = res.values[0];
+    t.is(activeSprint.state, 'active');
+    t.is(activeSprint.id, 982);
+    t.is(activeSprint.self, "https://actocloud.atlassian.net/rest/agile/1.0/sprint/982");
+    t.is(activeSprint.originBoardId, 167);
+});
+
+test('getIssuesInSprint(sprintId) should return the issues in the active sprint for board 167', async t => {
+    const res = await Sp.getSprints(167);
+    const sprintId = res.values[0].id;
+    const issues = await Sp.getIssuesInSprint(sprintId);
+    
+    t.true(issues.length > 0);
+
+    // Validate the structure of the first issue
+    const firstIssue = issues[0];
+    t.true(typeof firstIssue.id === 'string');
+    t.true(typeof firstIssue.key === 'string');
+    t.true(typeof firstIssue.fields === 'object');
+    t.truthy(firstIssue.fields.summary);
+});


### PR DESCRIPTION
… reason being is many metrics will use sprints so this can be reused rather than in a single metric. I also reviewed and made small changes in the story_point_controller.js and added content to the toolPlugin interace. I will have to refactor the toolPlugin interface and the story_point_controller in the future as neither do what is now needed. I will get this ready for the Jira web hook sending estimated and committed story points to a Node/Express backend route and make use the story_point_controller